### PR TITLE
Fixed accidental absolute path

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -68,7 +68,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "C:/Users/jmatt/Game Development/Unity/GGJ2023/Documentation"
+OUTPUT_DIRECTORY       = "Documentation"
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format


### PR DESCRIPTION
This change accidentally got left out of the previous commit and PR. Properly resolves #78.